### PR TITLE
Convert elasticsearch index settings to a template

### DIFF
--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -35,7 +35,9 @@
   when: elasticsearch_index_settings is defined
   uri:
     method: PUT
-    url: http://localhost:9200/_settings
+    url: http://localhost:9200/_template/all
     body_format: json  # This will convert yaml data to a json string
     body:
-      index: "{{ elasticsearch_index_settings }}"
+      template: '*'
+      order: 0
+      settings: "{{ elasticsearch_index_settings }}"


### PR DESCRIPTION
Setting cluster index settings via /_settings is not available until after
at least one index has been created. So instead, create an index template
named "all" that applies to all indices to set the index settings.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>